### PR TITLE
Adding external traffic policy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: valheim
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.142.6
 description: Valheim dedicated server.
 keywords:

--- a/templates/valheim-svc.yaml
+++ b/templates/valheim-svc.yaml
@@ -23,6 +23,7 @@ spec:
     port: {{ .Values.valheimServer.serverPort | int | add 2 }}
     targetPort: valheim-3
     protocol: UDP
+    externalTrafficPolicy: {{ .Values.valheimServer.externalTrafficPolicy }}
   {{- else }}
   - name: valheim-1
     port: {{ .Values.valheimServer.serverPort | int }}

--- a/values.yaml
+++ b/values.yaml
@@ -23,6 +23,7 @@ valheimServer:
   backupsDirectory: /config/backups
   backupsMaxAge: 3 # 3 days
   serviceType: LoadBalancer
+  externalTrafficPolicy: Cluster
 
 persistence:
   config:


### PR DESCRIPTION
Depending on merge order, or time, this may have to change chart versions.

This PR adds control over the service external traffic policy. The default is Cluster, which matches the k8s default.